### PR TITLE
fix build error on Linux v4.2

### DIFF
--- a/mt7601u.h
+++ b/mt7601u.h
@@ -393,4 +393,6 @@ void mt7601u_dma_cleanup(struct mt7601u_dev *dev);
 int mt7601u_dma_enqueue_tx(struct mt7601u_dev *dev, struct sk_buff *skb,
 			   struct mt76_wcid *wcid, int hw_q);
 
+void* devm_kmemdup(struct mt7601u_dev *dev, const struct ieee80211_channel, int, GFP_KERNEL)
+
 #endif


### PR DESCRIPTION
added declaration of devm_kmemdup to fix not declare
method on build

Signed-off-by: Ashish Namdev <ashish28.sirt@gmail.com>